### PR TITLE
Replace default `id` parameter to use `place_id`, as `id` is deprecated.

### DIFF
--- a/jquery.placecomplete.js
+++ b/jquery.placecomplete.js
@@ -163,6 +163,7 @@ Plugin.prototype.init = function() {
                         // for each autocomplete list item. "id" is
                         // already defined on the apr object
                         apr["text"] = apr["description"];
+                        apr["id"] = apr["place_id"];
                         return apr;
                     });
                     query.callback({results: results});


### PR DESCRIPTION
Addresses issue #14 . Changes to pass the `place_id` field of the Google Places response to the `id` parameter of the select2 query.